### PR TITLE
Feature/LGCS-570 (Static pages)

### DIFF
--- a/CyberHealth/static/src/scss/app.scss
+++ b/CyberHealth/static/src/scss/app.scss
@@ -1,3 +1,1 @@
-.temp-content-warning {
-    color: $govuk-error-colour;
-}
+// styles go in here

--- a/CyberHealth/static/src/scss/app.scss
+++ b/CyberHealth/static/src/scss/app.scss
@@ -1,3 +1,3 @@
-.govuk-heading-xl {
+.temp-content-warning {
     color: $govuk-error-colour;
 }

--- a/CyberHealth/staticpages/templates/staticpages/accessibility-statement.html
+++ b/CyberHealth/staticpages/templates/staticpages/accessibility-statement.html
@@ -1,0 +1,42 @@
+{% extends 'base.html' %}
+{% block content %}
+  <div class="govuk-width-container ">
+    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+      <h1 class="govuk-heading-xl">Accessibility statement</h1>
+
+      <p class="temp-content-warning">
+          This is placeholder content.
+      </p>
+
+      <p>
+        This statement applies to content published on the XXXXX domain. It does not apply to content on XXXXX subdomains.
+      </p>
+
+      <p>
+        This website is run by XXXXX. It is designed to be used by as many people as possible. The text should be clear and simple to understand. You should be able to:
+      </p>
+
+      <ul>
+        <li>zoom in up to 300% without problems</li>
+        <li>navigate most of the website using just a keyboard</li>
+        <li>navigate most of the website using speech recognition software</li>
+        <li>use most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)</li>
+      </ul>
+
+    <h2>How accessible this website is</h2>
+    <h2>Accessibility on subdomains</h2>
+    <h2>Feedback and contact information</h2>
+    <h2>Reporting accessibility problems with this website</h2>
+    <h2>Enforcement procedure</h2>
+    <h2>Technical information about this websites accessibility</h2>
+    <h2>Compliance status</h2>
+    <h2>Non accessible content</h2>
+    <h2>How we tested this website</h2>
+    <h2>What were doing to improve accessibility</h2>
+    <h2>Preparation of this accessibility statement</h2>
+
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/CyberHealth/staticpages/templates/staticpages/accessibility-statement.html
+++ b/CyberHealth/staticpages/templates/staticpages/accessibility-statement.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Accessibility statement - Cyber health assessment{% endblock %}
 {% block content %}
   <div class="govuk-width-container ">
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">

--- a/CyberHealth/staticpages/templates/staticpages/accessibility-statement.html
+++ b/CyberHealth/staticpages/templates/staticpages/accessibility-statement.html
@@ -4,10 +4,6 @@
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
       <h1 class="govuk-heading-xl">Accessibility statement</h1>
 
-      <p class="temp-content-warning">
-          This is placeholder content.
-      </p>
-
       <p>
         This statement applies to content published on the XXXXX domain. It does not apply to content on XXXXX subdomains.
       </p>

--- a/CyberHealth/staticpages/templates/staticpages/cookie-policy.html
+++ b/CyberHealth/staticpages/templates/staticpages/cookie-policy.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+{% block content %}
+  <div class="govuk-width-container ">
+    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+      <h1 class="govuk-heading-xl">Cookie policy</h1>
+
+      <p class="temp-content-warning">
+          This is placeholder content. It is important to review whether this page is necessary or not!
+      </p>
+
+      <p>
+        If required, this page could include information about:
+    </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>Cookies that measure website use (we may not need this if using Piwik(?))</li>
+        <li>Cookies that help with our communications and marketing</li>
+        <li>Cookies that help with communications/marketing</li>
+        <li>Cookies that remember user settings</li>
+        <li>Any absolutely necessary cookies (e.g. tracking progress through a form).</li>
+      </ul>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/CyberHealth/staticpages/templates/staticpages/cookie-policy.html
+++ b/CyberHealth/staticpages/templates/staticpages/cookie-policy.html
@@ -4,10 +4,6 @@
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
       <h1 class="govuk-heading-xl">Cookie policy</h1>
 
-      <p class="temp-content-warning">
-          This is placeholder content. It is important to review whether this page is necessary or not!
-      </p>
-
       <p>
         If required, this page could include information about:
     </p>

--- a/CyberHealth/staticpages/templates/staticpages/cookie-policy.html
+++ b/CyberHealth/staticpages/templates/staticpages/cookie-policy.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Cookie policy - Cyber health assessment{% endblock %}
 {% block content %}
   <div class="govuk-width-container ">
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">

--- a/CyberHealth/staticpages/templates/staticpages/index.html
+++ b/CyberHealth/staticpages/templates/staticpages/index.html
@@ -3,8 +3,50 @@
 
 
   <div class="govuk-width-container ">
-    <main class="govuk-main-wrapper " id="main-content" role="main">
-      <h1 class="govuk-heading-xl">Default page template</h1>
+    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+      <h1 class="govuk-heading-xl">Assess your cyber health</h1>
+
+      <p class="temp-content-warning">
+          This is placeholder content taken from the 
+          <a href="https://github.com/WeAreSnook/MHCLG-CS-prototype-2.0/commit/528296ba7701cba89aff0f4ef2956a6e7fee5ff4#diff-7571557a64688c6af77abae6dedb31183578cfab6b125ba3748f12595a705cc3">
+            Sprint 6 prototype
+          </a>.
+      </p>
+
+      <p>
+        This self-assessment will help you to:
+      </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+          <li>Determine your organisation’s current level of cyber health against the three progression levels</li>
+          <li>Receive feedback on what your current risks are, and guidance on how to take action</li>
+          <li>Understand what you need to do to progress to the next level</li>
+        </ul>
+        
+        <p>By meeting particular sections of the self-assessment you’ll also be able to achieve your PSN and NHS DSTP compliance, and see how you are meeting other common standards.</p>
+    
+        <p>The self-assessment will provide recommendations based on your answers, and you can save your progress and resume at any time</p>
+    
+        <a
+          href="/assessment"
+          role="button"
+          draggable="false"
+          class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"
+          data-module="govuk-button"
+        >
+          Start self-assessment
+          <svg
+            class="govuk-button__start-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            width="17.5"
+            height="19"
+            viewBox="0 0 33 40"
+            role="presentation"
+            focusable="false"
+          >
+            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z"></path>
+          </svg>
+        </a>
     </main>
   </div>
 

--- a/CyberHealth/staticpages/templates/staticpages/index.html
+++ b/CyberHealth/staticpages/templates/staticpages/index.html
@@ -6,13 +6,6 @@
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
       <h1 class="govuk-heading-xl">Assess your cyber health</h1>
 
-      <p class="temp-content-warning">
-          This is placeholder content taken from the 
-          <a href="https://github.com/WeAreSnook/MHCLG-CS-prototype-2.0/commit/528296ba7701cba89aff0f4ef2956a6e7fee5ff4#diff-7571557a64688c6af77abae6dedb31183578cfab6b125ba3748f12595a705cc3">
-            Sprint 6 prototype
-          </a>.
-      </p>
-
       <p>
         This self-assessment will help you to:
       </p>

--- a/CyberHealth/staticpages/templates/staticpages/index.html
+++ b/CyberHealth/staticpages/templates/staticpages/index.html
@@ -1,4 +1,5 @@
-{% extends 'base.html' %} 
+{% extends 'base.html' %}
+{% block title %}Cyber health assessment{% endblock %}
 {% block content %}
 
 

--- a/CyberHealth/staticpages/templates/staticpages/privacy-policy.html
+++ b/CyberHealth/staticpages/templates/staticpages/privacy-policy.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block content %}
+  <div class="govuk-width-container ">
+    <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
+      <h1 class="govuk-heading-xl">Privacy policy</h1>
+
+      <p class="temp-content-warning">
+          This is placeholder content.
+      </p>
+
+      <p>
+        This page could include information about:
+    </p>
+
+      <ul class="govuk-list govuk-list--bullet">
+        <li>What data we collect</li>
+        <li>Why we need your data</li>
+        <li>Our legal basis for processing your data</li>
+        <li>How long we keep your data</li>
+        <li>Children's privacy protection</li>
+        <li>Where your data is processed and stored</li>
+        <li>How we protect your data and keep it secure</li>
+        <li>Your rights</li>
+        <li>Links to other websites</li>
+        <li>Information accessed via this Cyber Health Assessment</li>
+        <li>Contact us or make a complaint</li>
+      </ul>
+
+    </main>
+  </div>
+
+{% endblock %}

--- a/CyberHealth/staticpages/templates/staticpages/privacy-policy.html
+++ b/CyberHealth/staticpages/templates/staticpages/privacy-policy.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% block title %}Accessibility statement - Cyber health assessment{% endblock %}
 {% block content %}
   <div class="govuk-width-container ">
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">

--- a/CyberHealth/staticpages/templates/staticpages/privacy-policy.html
+++ b/CyberHealth/staticpages/templates/staticpages/privacy-policy.html
@@ -4,10 +4,6 @@
     <main class="govuk-main-wrapper govuk-body" id="main-content" role="main">
       <h1 class="govuk-heading-xl">Privacy policy</h1>
 
-      <p class="temp-content-warning">
-          This is placeholder content.
-      </p>
-
       <p>
         This page could include information about:
     </p>

--- a/CyberHealth/staticpages/tests/tests_views.py
+++ b/CyberHealth/staticpages/tests/tests_views.py
@@ -15,3 +15,14 @@ class StaticPageViewTest(TestCase):
         response = self.client.get(reverse('static-page'))
         self.assertTemplateUsed(response, 'staticpages/index.html')
 
+    def test_can_render_privacy_policy(self):
+        response = self.client.get('/privacy-policy')
+        self.assertTemplateUsed(response, 'staticpages/privacy-policy.html')
+    
+    def test_can_render_cookie_policy(self):
+        response = self.client.get('/cookie-policy')
+        self.assertTemplateUsed(response, 'staticpages/cookie-policy.html')
+    
+    def test_can_render_accessibility_statement(self):
+        response = self.client.get('/accessibility-statement')
+        self.assertTemplateUsed(response, 'staticpages/accessibility-statement.html')

--- a/CyberHealth/staticpages/urls.py
+++ b/CyberHealth/staticpages/urls.py
@@ -4,4 +4,5 @@ from . import views
 
 urlpatterns = [
     path('', views.start_page, name='static-page'),
+    path('privacy-policy', views.privacy_policy, name="privacy-policy"),
 ]

--- a/CyberHealth/staticpages/urls.py
+++ b/CyberHealth/staticpages/urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path('', views.start_page, name='static-page'),
     path('privacy-policy', views.privacy_policy, name="privacy-policy"),
+    path('cookie-policy', views.cookie_policy, name="cookie-policy"),
 ]

--- a/CyberHealth/staticpages/urls.py
+++ b/CyberHealth/staticpages/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('', views.start_page, name='static-page'),
     path('privacy-policy', views.privacy_policy, name="privacy-policy"),
     path('cookie-policy', views.cookie_policy, name="cookie-policy"),
+    path('accessibility-statement', views.accessibility_statement, name="accessibility-statement"),
 ]

--- a/CyberHealth/staticpages/views.py
+++ b/CyberHealth/staticpages/views.py
@@ -11,3 +11,6 @@ def privacy_policy(request):
 
 def cookie_policy(request):
     return render(request, 'staticpages/cookie-policy.html')
+
+def accessibility_statement(request):
+    return render(request, 'staticpages/accessibility-statement.html')

--- a/CyberHealth/staticpages/views.py
+++ b/CyberHealth/staticpages/views.py
@@ -5,3 +5,6 @@ from django.shortcuts import render
 @basic_auth_required
 def start_page(request):
     return render(request, 'staticpages/index.html')
+
+def privacy_policy(request):
+    return render(request, 'staticpages/privacy-policy.html')

--- a/CyberHealth/staticpages/views.py
+++ b/CyberHealth/staticpages/views.py
@@ -8,3 +8,6 @@ def start_page(request):
 
 def privacy_policy(request):
     return render(request, 'staticpages/privacy-policy.html')
+
+def cookie_policy(request):
+    return render(request, 'staticpages/cookie-policy.html')

--- a/acceptance/features/accessibility-statement.feature
+++ b/acceptance/features/accessibility-statement.feature
@@ -1,0 +1,6 @@
+Feature: Accessibility statement page
+
+Scenario: Accessibility statement page contains expected heading
+Given I am a Cyber Capable Person interested in accessibility
+When I visit the Cyber Health Framework site Accessibility statement page
+Then I see a page with the heading "Accessibility statement"

--- a/acceptance/features/cookie-policy.feature
+++ b/acceptance/features/cookie-policy.feature
@@ -1,0 +1,6 @@
+Feature: Cookie policy page
+
+Scenario: Cookie policy page contains expected heading
+Given I am a Cyber Capable Person
+When I visit the Cyber Health Framework site Cookie policy page
+Then I see a page with the heading "Cookie policy"

--- a/acceptance/features/index.feature
+++ b/acceptance/features/index.feature
@@ -1,6 +1,6 @@
 Feature: Index page loads
 
-Scenario: Index page contains expected text
+Scenario: Index page contains expected heading
 Given I am a Cyber Capable Person
 When I visit the Cyber Health Framework site
-Then I see the text "Default page template"
+Then I see a page with the heading "Assess your cyber health"

--- a/acceptance/features/privacy-policy.feature
+++ b/acceptance/features/privacy-policy.feature
@@ -1,0 +1,6 @@
+Feature: Privacy policy page
+
+Scenario: Privacy policy page contains expected heading
+Given I am a Cyber Capable Person
+When I visit the Cyber Health Framework site Privacy policy page
+Then I see a page with the heading "Privacy policy"

--- a/acceptance/steps/accessibility-statement.test.js
+++ b/acceptance/steps/accessibility-statement.test.js
@@ -1,0 +1,41 @@
+const JestCucumber = require('jest-cucumber')
+const WebDriver = require('selenium-webdriver');
+const firefox = require('selenium-webdriver/firefox');
+
+const screen = {
+  width: 1024,
+  height: 768
+};
+
+const feature = JestCucumber.loadFeature('features/accessibility-statement.feature');
+
+JestCucumber.defineFeature(feature, test => {
+  test('Accessibility statement page contains expected heading', ({ given, when, then }) => {
+
+    let url = "";
+    let driver;
+
+    given('I am a Cyber Capable Person interested in accessibility', () => {
+      driver = new WebDriver.Builder()
+        .withCapabilities(WebDriver.Capabilities.firefox())
+        .setFirefoxOptions(new firefox.Options()
+          .headless()
+          .windowSize(screen)
+        )
+        .build();
+    });
+
+    when('I visit the Cyber Health Framework site Accessibility statement page', async () => {
+      const urlStub = 'accessibility-statement'
+      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}/${urlStub}`
+      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+    });
+
+    then(/I see a page with the heading \"(.*)\"/, async (expected) => {
+      const pageTitle = await driver.findElement(WebDriver.By.id('main-content'))
+      const actual = await pageTitle.getText()
+      expect(actual).toContain(expected)
+      driver.quit();
+    });
+  });
+});

--- a/acceptance/steps/cookie-policy.test.js
+++ b/acceptance/steps/cookie-policy.test.js
@@ -1,0 +1,41 @@
+const JestCucumber = require('jest-cucumber')
+const WebDriver = require('selenium-webdriver');
+const firefox = require('selenium-webdriver/firefox');
+
+const screen = {
+  width: 1024,
+  height: 768
+};
+
+const feature = JestCucumber.loadFeature('features/cookie-policy.feature');
+
+JestCucumber.defineFeature(feature, test => {
+  test('Cookie policy page contains expected heading', ({ given, when, then }) => {
+
+    let url = "";
+    let driver;
+
+    given('I am a Cyber Capable Person', () => {
+      driver = new WebDriver.Builder()
+        .withCapabilities(WebDriver.Capabilities.firefox())
+        .setFirefoxOptions(new firefox.Options()
+          .headless()
+          .windowSize(screen)
+        )
+        .build();
+    });
+
+    when('I visit the Cyber Health Framework site Cookie policy page', async () => {
+      const urlStub = 'cookie-policy'
+      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}/${urlStub}`
+      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+    });
+
+    then(/I see a page with the heading \"(.*)\"/, async (expected) => {
+      const pageTitle = await driver.findElement(WebDriver.By.id('main-content'))
+      const actual = await pageTitle.getText()
+      expect(actual).toContain(expected)
+      driver.quit();
+    });
+  });
+});

--- a/acceptance/steps/index.test.js
+++ b/acceptance/steps/index.test.js
@@ -10,7 +10,7 @@ const screen = {
 const feature = JestCucumber.loadFeature('features/index.feature');
 
 JestCucumber.defineFeature(feature, test => {
-    test('Index page contains expected text', ({ given, when, then }) => {
+    test('Index page contains expected heading', ({ given, when, then }) => {
 
         let url = "";
         let driver;
@@ -30,11 +30,11 @@ JestCucumber.defineFeature(feature, test => {
             await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
         });
 
-        then(/I see the text \"(.*)\"/, async(expected) => {
+        then(/I see a page with the heading \"(.*)\"/, async(expected) => {
             // do nothing
             const pageTitle = await driver.findElement(WebDriver.By.id('main-content'))
             const actual = await pageTitle.getText()
-            expect(actual).toEqual(expected)
+            expect(actual).toContain(expected)
             driver.quit();
         });
     });

--- a/acceptance/steps/privacy-policy.test.js
+++ b/acceptance/steps/privacy-policy.test.js
@@ -1,0 +1,41 @@
+const JestCucumber = require('jest-cucumber')
+const WebDriver = require('selenium-webdriver');
+const firefox = require('selenium-webdriver/firefox');
+
+const screen = {
+  width: 1024,
+  height: 768
+};
+
+const feature = JestCucumber.loadFeature('features/privacy-policy.feature');
+
+JestCucumber.defineFeature(feature, test => {
+  test('Privacy policy page contains expected heading', ({ given, when, then }) => {
+
+    let url = "";
+    let driver;
+
+    given('I am a Cyber Capable Person', () => {
+      driver = new WebDriver.Builder()
+        .withCapabilities(WebDriver.Capabilities.firefox())
+        .setFirefoxOptions(new firefox.Options()
+          .headless()
+          .windowSize(screen)
+        )
+        .build();
+    });
+
+    when('I visit the Cyber Health Framework site Privacy policy page', async () => {
+      const urlStub = 'privacy-policy'
+      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}/${urlStub}`
+      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+    });
+
+    then(/I see a page with the heading \"(.*)\"/, async (expected) => {
+      const pageTitle = await driver.findElement(WebDriver.By.id('main-content'))
+      const actual = await pageTitle.getText()
+      expect(actual).toContain(expected)
+      driver.quit();
+    });
+  });
+});

--- a/accessibility/test.js
+++ b/accessibility/test.js
@@ -2,30 +2,52 @@ const AxeBuilder = require('@axe-core/webdriverjs');
 const WebDriver = require('selenium-webdriver');
 const firefox = require('selenium-webdriver/firefox');
 
+const baseUrl = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
+const pagesToAnalyze = [
+    '/',
+    'accessibility-statement',
+    'cookie-policy',
+    'privacy-policy',
+]
+
 const screen = {
     width: 1024,
     height: 768
 };
 
-driver = new WebDriver.Builder()
+const buildDriver = () => {
+    return new WebDriver.Builder()
     .withCapabilities(WebDriver.Capabilities.firefox())
     .setFirefoxOptions(new firefox.Options()
         .headless()
         .windowSize(screen)
     )
     .build();
+}
 
-let url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
 
-driver.get(url).then(() => {
-    const axe = new AxeBuilder(driver, null, { noSandbox: true });
-    axe.analyze(async(err, results) => {
-        if (err) {
-            // Handle error somehow
-            console.error(results);
-            process.exit(1);
-        }
-        console.log(results);
-        await driver.quit();
+function runAccessibilityAnalysis(pages) {
+    const urls = pages.map(page => new URL(page, baseUrl))
+    urls.forEach(url => {
+        let driver = buildDriver();
+        analyzePage(driver, url).then(result => {
+            console.log(result);
+        }).catch(err => {
+            console.err(err);
+        });
     });
-});
+}
+
+async function analyzePage(driver, url) {
+    try {
+        await driver.get(url);
+        const axe = new AxeBuilder(driver, null, { noSandbox: true });
+        let result = await axe.analyze();
+        return Promise.resolve(result);
+    }
+    catch (err) {
+        return Promise.reject(err);
+    }
+}
+
+runAccessibilityAnalysis(pagesToAnalyze);


### PR DESCRIPTION
This PR encompasses the work for ticket [LGCS-570](https://digital.dclg.gov.uk/jira/browse/LGCS-570) and each of it's subtasks (except 632 Demo to the team).

- Add a static start page - visible at `/` route
- Add a static privacy page - visible at `/privacy-policy` route
- Add a static Cookie page - visible at `/cookie-policy` route
- Add a static accessibility page - visible at `/accessibility-statement` route
- Add acceptance tests for the static pages
- Add accessibility tests for the static pages

Content for each of these pages is placeholder only.

This ticket _does not_:
- render any links between these static pages (except the index route, already linked in multiple places in the app).

---

Running accessibility tests for multiple pages was the most challenging part of this work and the part I think would benefit from the most thorough review (see file `accessibility/test.js` / commit 61edf18).