### PR TITLE
Feature/LGCS-571 (Link to static pages in footer) 

### DIFF
--- a/CyberHealth/templates/partials/_footer.html
+++ b/CyberHealth/templates/partials/_footer.html
@@ -2,6 +2,18 @@
     <div class="govuk-width-container ">
       <div class="govuk-footer__meta">
         <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <h2 class="govuk-visually-hidden">Support links</h2>
+          <ul class="govuk-footer__inline-list">
+            <li class="govuk-footer__inline-list-item">
+              <a href="/privacy-policy" class="govuk-footer__link">Privacy</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a href="/cookie-policy" class="govuk-footer__link">Cookies</a>
+            </li>
+            <li class="govuk-footer__inline-list-item">
+              <a href="/accessibility-statement" class="govuk-footer__link">Accessibility statement</a>
+            </li>
+          </ul>
 
           <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
             <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />

--- a/acceptance/features/footer.feature
+++ b/acceptance/features/footer.feature
@@ -1,4 +1,4 @@
-Feature: Index page loads
+Feature: Static footer
 
 Scenario: Footer contains link to privacy policy
 Given I am a Cyber Capable Person

--- a/acceptance/features/footer.feature
+++ b/acceptance/features/footer.feature
@@ -1,0 +1,6 @@
+Feature: Index page loads
+
+Scenario: Footer contains link to privacy policy
+Given I am a Cyber Capable Person
+When I visit the Cyber Health Framework site
+Then I see a link to "/privacy-policy" in the footer

--- a/acceptance/features/footer.feature
+++ b/acceptance/features/footer.feature
@@ -9,3 +9,8 @@ Scenario: Footer contains link to cookie policy
 Given I am a Cyber Capable Person
 When I visit the Cyber Health Framework site
 Then I see a link to "/cookie-policy" in the footer
+
+Scenario: Footer contains link to Accessibility statement
+Given I am a Cyber Capable Person
+When I visit the Cyber Health Framework site
+Then I see a link to "/accessibility-statement" in the footer

--- a/acceptance/features/footer.feature
+++ b/acceptance/features/footer.feature
@@ -4,3 +4,8 @@ Scenario: Footer contains link to privacy policy
 Given I am a Cyber Capable Person
 When I visit the Cyber Health Framework site
 Then I see a link to "/privacy-policy" in the footer
+
+Scenario: Footer contains link to cookie policy
+Given I am a Cyber Capable Person
+When I visit the Cyber Health Framework site
+Then I see a link to "/cookie-policy" in the footer

--- a/acceptance/steps/footer.test.js
+++ b/acceptance/steps/footer.test.js
@@ -1,0 +1,40 @@
+const JestCucumber = require('jest-cucumber')
+const WebDriver = require('selenium-webdriver');
+const firefox = require('selenium-webdriver/firefox');
+
+const screen = {
+  width: 1024,
+  height: 768
+};
+
+const feature = JestCucumber.loadFeature('features/footer.feature');
+
+JestCucumber.defineFeature(feature, test => {
+  test('Footer contains link to privacy policy', ({ given, when, then }) => {
+
+    let url = "";
+    let driver;
+
+    given('I am a Cyber Capable Person', () => {
+      driver = new WebDriver.Builder()
+        .withCapabilities(WebDriver.Capabilities.firefox())
+        .setFirefoxOptions(new firefox.Options()
+          .headless()
+          .windowSize(screen)
+        )
+        .build();
+    });
+
+    when('I visit the Cyber Health Framework site', async () => {
+      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
+      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+    });
+
+    then(/I see a link to \"(.*)\" in the footer/, async (expected) => {
+      const footerElement = await driver.findElement(WebDriver.By.css(`footer a[href="${expected}"]`));
+      const actualFooterElement = await footerElement.getText();
+      expect(actualFooterElement).toEqual('Privacy');
+      driver.quit();
+    });
+  });
+});

--- a/acceptance/steps/footer.test.js
+++ b/acceptance/steps/footer.test.js
@@ -37,4 +37,32 @@ JestCucumber.defineFeature(feature, test => {
       driver.quit();
     });
   });
+
+  test('Footer contains link to cookie policy', ({ given, when, then }) => {
+
+    let url = "";
+    let driver;
+
+    given('I am a Cyber Capable Person', () => {
+      driver = new WebDriver.Builder()
+        .withCapabilities(WebDriver.Capabilities.firefox())
+        .setFirefoxOptions(new firefox.Options()
+          .headless()
+          .windowSize(screen)
+        )
+        .build();
+    });
+
+    when('I visit the Cyber Health Framework site', async () => {
+      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
+      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+    });
+
+    then(/I see a link to \"(.*)\" in the footer/, async (expected) => {
+      const footerElement = await driver.findElement(WebDriver.By.css(`footer a[href="${expected}"]`));
+      const actualFooterElement = await footerElement.getText();
+      expect(actualFooterElement).toEqual('Cookies');
+      driver.quit();
+    });
+  });
 });

--- a/acceptance/steps/footer.test.js
+++ b/acceptance/steps/footer.test.js
@@ -65,4 +65,32 @@ JestCucumber.defineFeature(feature, test => {
       driver.quit();
     });
   });
+
+  test('Footer contains link to Accessibility statement', ({ given, when, then }) => {
+
+    let url = "";
+    let driver;
+
+    given('I am a Cyber Capable Person', () => {
+      driver = new WebDriver.Builder()
+        .withCapabilities(WebDriver.Capabilities.firefox())
+        .setFirefoxOptions(new firefox.Options()
+          .headless()
+          .windowSize(screen)
+        )
+        .build();
+    });
+
+    when('I visit the Cyber Health Framework site', async () => {
+      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
+      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+    });
+
+    then(/I see a link to \"(.*)\" in the footer/, async (expected) => {
+      const footerElement = await driver.findElement(WebDriver.By.css(`footer a[href="${expected}"]`));
+      const actualFooterElement = await footerElement.getText();
+      expect(actualFooterElement).toEqual('Accessibility statement');
+      driver.quit();
+    });
+  });
 });

--- a/acceptance/steps/footer.test.js
+++ b/acceptance/steps/footer.test.js
@@ -1,96 +1,65 @@
 const JestCucumber = require('jest-cucumber')
-const WebDriver = require('selenium-webdriver');
-const firefox = require('selenium-webdriver/firefox');
-
-const screen = {
-  width: 1024,
-  height: 768
-};
+const FirefoxDriver = require('../helpers/FirefoxDriver.js');
 
 const feature = JestCucumber.loadFeature('features/footer.feature');
 
 JestCucumber.defineFeature(feature, test => {
+  let driver;
+
+  beforeAll(() => {
+    driver = new FirefoxDriver();
+  });
+
   test('Footer contains link to privacy policy', ({ given, when, then }) => {
-
-    let url = "";
-    let driver;
-
-    given('I am a Cyber Capable Person', () => {
-      driver = new WebDriver.Builder()
-        .withCapabilities(WebDriver.Capabilities.firefox())
-        .setFirefoxOptions(new firefox.Options()
-          .headless()
-          .windowSize(screen)
-        )
-        .build();
-    });
+    given('I am a Cyber Capable Person', () => {});
 
     when('I visit the Cyber Health Framework site', async () => {
-      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
-      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+      // visit home route
+      await driver.visitPage('');
     });
 
     then(/I see a link to \"(.*)\" in the footer/, async (expected) => {
-      const footerElement = await driver.findElement(WebDriver.By.css(`footer a[href="${expected}"]`));
+      const footerElement = await driver.findElement(`footer a[href="${expected}"]`);
       const actualFooterElement = await footerElement.getText();
       expect(actualFooterElement).toEqual('Privacy');
-      driver.quit();
+      // driver.quit();
     });
   });
 
   test('Footer contains link to cookie policy', ({ given, when, then }) => {
-
-    let url = "";
-    let driver;
-
-    given('I am a Cyber Capable Person', () => {
-      driver = new WebDriver.Builder()
-        .withCapabilities(WebDriver.Capabilities.firefox())
-        .setFirefoxOptions(new firefox.Options()
-          .headless()
-          .windowSize(screen)
-        )
-        .build();
-    });
+    given('I am a Cyber Capable Person', () => {});
 
     when('I visit the Cyber Health Framework site', async () => {
-      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
-      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+      // visit home route
+      await driver.visitPage('');
     });
 
     then(/I see a link to \"(.*)\" in the footer/, async (expected) => {
-      const footerElement = await driver.findElement(WebDriver.By.css(`footer a[href="${expected}"]`));
+      const footerElement = await driver.findElement(`footer a[href="${expected}"]`);
       const actualFooterElement = await footerElement.getText();
       expect(actualFooterElement).toEqual('Cookies');
-      driver.quit();
+      // driver.quit();
     });
   });
 
   test('Footer contains link to Accessibility statement', ({ given, when, then }) => {
-
-    let url = "";
-    let driver;
-
-    given('I am a Cyber Capable Person', () => {
-      driver = new WebDriver.Builder()
-        .withCapabilities(WebDriver.Capabilities.firefox())
-        .setFirefoxOptions(new firefox.Options()
-          .headless()
-          .windowSize(screen)
-        )
-        .build();
-    });
+    given('I am a Cyber Capable Person', () => {});
 
     when('I visit the Cyber Health Framework site', async () => {
-      url = `${process.env.FRONTEND_PROTO}://${process.env.FRONTEND_HOST}:${process.env.FRONTEND_PORT}`
-      await driver.get(url).catch(urlCaptureException => { console.error(urlCaptureException) })
+      // visit home route
+      await driver.visitPage('');
     });
 
     then(/I see a link to \"(.*)\" in the footer/, async (expected) => {
-      const footerElement = await driver.findElement(WebDriver.By.css(`footer a[href="${expected}"]`));
+      const footerElement = await driver.findElement(`footer a[href="${expected}"]`);
       const actualFooterElement = await footerElement.getText();
       expect(actualFooterElement).toEqual('Accessibility statement');
-      driver.quit();
+      // driver.quit();
     });
+
+  });
+
+  afterAll(() => {
+    driver.quit();
   });
 });


### PR DESCRIPTION
**Depends on #60**

This PR encompasses the work for ticket [LGCS-571](https://digital.dclg.gov.uk/jira/browse/LGCS-571) and two of its subtasks (not 633 Demo to the team).

- Link to static privacy page `/privacy-policy`
- Link to static Cookie page `/cookie-policy`
- Link to static accessibility page`/accessibility-statement`
- Add acceptance tests to show that the links render as part of the footer