### PR TITLE
LGCS-712: Django upgrade

### DIFF
--- a/CyberHealth/Pipfile
+++ b/CyberHealth/Pipfile
@@ -9,13 +9,13 @@ environ = "==1.0"
 whitenoise = "==5.2.0"
 django-environ = "==0.4.5"
 wheel = "==0.36.2"
-asgiref = "==3.3.1"
 psycopg2 = "==2.8.6"
 django-basicauth = "==0.5.3"
 pytz = "==2021.1"
 sqlparse = "==0.4.1"
-Django = "==3.1.7"
 django-cors-headers = "==3.7.0"
+django = "==3.2.3"
+asgiref = "==3.3.2"
 
 [dev-packages]
 

--- a/CyberHealth/Pipfile.lock
+++ b/CyberHealth/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f09ab0f0aa98406d843697934912e8dff46fdfc8709d400150838b89337b4cf"
+            "sha256": "54246acee082f336340f5109c038173b2562904550db39d6ca8a5a4eb4efc7ab"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,19 +18,19 @@
     "default": {
         "asgiref": {
             "hashes": [
-                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
-                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
+                "sha256:34103fa20270d8843a66e5df18547d2e8139534d23e3beffe96647c65ddffd4d",
+                "sha256:c62b616b226d6c2e927b0225f8101f9e2cca08112cff98839ca6726c129ff9e0"
             ],
             "index": "pypi",
-            "version": "==3.3.1"
+            "version": "==3.3.2"
         },
         "django": {
             "hashes": [
-                "sha256:32ce792ee9b6a0cbbec340123e229ac9f765dff8c2a4ae9247a14b2ba3a365a7",
-                "sha256:baf099db36ad31f970775d0be5587cc58a6256a6771a44eb795b554d45f211b8"
+                "sha256:13ac78dbfd189532cad8f383a27e58e18b3d33f80009ceb476d7fcbfc5dcebd8",
+                "sha256:7e0a1393d18c16b503663752a8b6790880c5084412618990ce8a81cc908b4962"
             ],
             "index": "pypi",
-            "version": "==3.1.7"
+            "version": "==3.2.3"
         },
         "django-basicauth": {
             "hashes": [

--- a/CyberHealth/requirements.txt
+++ b/CyberHealth/requirements.txt
@@ -6,11 +6,11 @@
 #
 
 -i https://pypi.org/simple
-asgiref==3.3.1
+asgiref==3.3.2
 django-basicauth==0.5.3
 django-cors-headers==3.7.0
 django-environ==0.4.5
-django==3.1.7
+django==3.2.3
 environ==1.0
 psycopg2==2.8.6
 pytz==2021.1


### PR DESCRIPTION
Upgrades `Django` to version `3.2.3`.

Also, as a result of this, upgrades `asgiref` to 3.3.2 (compatible with newest Django).