### PR TITLE
Adds `--quiet` flag to deployment npm install

### DIFF
--- a/CyberHealth/scripts/deploy.sh
+++ b/CyberHealth/scripts/deploy.sh
@@ -2,7 +2,7 @@
 
 echo "Building frontend assets before deployment"
 # Repeat frontend:build in order to populate dist folder on assets
-npm install
+npm install --quiet
 npm run frontend:build
 
 echo "Deploying to Gov.uk PAAS"


### PR DESCRIPTION
- Aims to reduce deployment logs by ≈5000 lines